### PR TITLE
Add padding to omfm_label_rounded_corners.xml

### DIFF
--- a/omfm/src/main/res/drawable/omfm_label_rounded_corners.xml
+++ b/omfm/src/main/res/drawable/omfm_label_rounded_corners.xml
@@ -3,6 +3,6 @@
     <solid android:color="#FFFFFF"/>
     <stroke android:width="1dp" android:color="#FFFFFF" />
     <corners android:radius="5dp"/>
-    <padding android:left="0dp" android:top="0dp" android:right="0dp" android:bottom="0dp" />
+    <padding android:left="2dp" android:top="0dp" android:right="2dp" android:bottom="0dp" />
 </shape>
 


### PR DESCRIPTION
Added padding to the left and right of the labels to make the title of the label readable with more space to breathe.